### PR TITLE
bugfix: håndtere 500-feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/soknad/api/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ba/soknad/api/config/ApiExceptionHandler.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.soknad.api.config
 
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -16,10 +17,10 @@ class ApiExceptionHandler {
         val feilmelding = (throwable.cause?.message ?: throwable.message).toString()
         secureLogger.info("En feil har oppstått: $feilmelding", throwable)
         LOG.error("En feil har oppstått: $feilmelding")
-        return if (throwable is HttpClientErrorException) {
-            ResponseEntity.status(throwable.statusCode).body(Ressurs.failure(feilmelding))
-        } else {
-            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Ressurs.failure(feilmelding))
+        return when (throwable) {
+            is HttpClientErrorException -> ResponseEntity.status(throwable.statusCode).body(Ressurs.failure(feilmelding))
+            is JwtTokenUnauthorizedException -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Ressurs.failure(feilmelding))
+            else -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Ressurs.failure(feilmelding))
         }
     }
 


### PR DESCRIPTION
Svar med HttpStatus 401 når backend får JwtTokenUnauthorizedException fordi det ikke er en subklasse av HttpClientErrorException. Så man vil ellers få en 500-feil