### PR TITLE
håndterer at ident er null og doedfodt, men sender de ikke

### DIFF
--- a/src/main/kotlin/no/nav/familie/ba/soknad/api/clients/pdl/PdlHentPersonResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ba/soknad/api/clients/pdl/PdlHentPersonResponse.kt
@@ -90,7 +90,7 @@ data class PdlSivilstand(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PdlFamilierelasjon(
-    val relatertPersonsIdent: String,
+    val relatertPersonsIdent: String? = null,
     val relatertPersonsRolle: FAMILIERELASJONSROLLE
 )
 
@@ -111,7 +111,8 @@ enum class FAMILIERELASJONSROLLE {
     BARN,
     FAR,
     MEDMOR,
-    MOR
+    MOR,
+    DOEDFOEDT_BARN
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/no/nav/familie/ba/soknad/api/services/pdl/mapper/PdlMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ba/soknad/api/services/pdl/mapper/PdlMapper.kt
@@ -51,7 +51,7 @@ object PdlMapper {
 
     fun mapFnrBarn(familierelasjoner: List<PdlFamilierelasjon>): List<String> {
         return familierelasjoner.filter { relasjon -> relasjon.relatertPersonsRolle == FAMILIERELASJONSROLLE.BARN }
-            .map { it.relatertPersonsIdent }
+            .mapNotNull { it.relatertPersonsIdent }
     }
 
     private fun mapStatsborgerskap(statsborgerskap: List<PdlStatsborgerskap>): List<Statborgerskap> {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Pdl har midlertidig lagt til relasjonen DOEDFOEDT_BARN, samt at relatertPersonsIdent kan være null. Denne PRen gjør at disse ikke blir sendt til frontend.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei
